### PR TITLE
[k8s] Agglomerating jobs

### DIFF
--- a/functions/kubernetes/buffer.js
+++ b/functions/kubernetes/buffer.js
@@ -1,0 +1,64 @@
+/**
+ * Class used for buffering jobs - kind of agglomeration.
+ */
+class BufferCountWithTimeout {
+  constructor(count, idleTimeoutMs, cb) {
+    this.elements = []
+    this.triggerCount = count;
+    this.idleTimeoutMs = idleTimeoutMs;
+    this.cb = cb;
+    this._rescheduleTimeout();
+  }
+
+  addItem(item) {
+    this.elements.push(item);
+    if (this.elements.length >= this.triggerCount) {
+      console.log("Running callback [reached count]");
+      let elementsCopy = this.elements;
+      this.elements = [];
+      this.cb(elementsCopy);
+    }
+    this._rescheduleTimeout();
+  }
+
+  _rescheduleTimeout() {
+    if (this.timeoutId) {
+      clearInterval(this.timeoutId);
+    }
+    this.timeoutId = setTimeout(() => {
+      console.log("Running callback [reached timeout]");
+      let elementsCopy = this.elements;
+      this.timeoutId = null;
+      this.elements = [];
+      this.cb(elementsCopy);
+    }, this.idleTimeoutMs);
+  }
+}
+
+/**
+ * Testing function.
+ * TODO: REMOVE
+ */
+async function testBuffer() {
+  let fn = (items) => {
+    console.log("Got from buffer:", items);
+  }
+  let test = new BufferCountWithTimeout(3, 1000, fn);
+  test.addItem(1);
+  test.addItem(2);
+  test.addItem(3);
+  test.addItem(4);
+  test.addItem(5);
+
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  test.addItem(6);
+  test.addItem(7);
+  test.addItem(8);
+  test.addItem(9);
+  test.addItem(10);
+  test.addItem(12);
+  test.addItem(13);
+}
+
+exports.BufferCountWithTimeout = BufferCountWithTimeout;

--- a/functions/kubernetes/buffer_manager.js
+++ b/functions/kubernetes/buffer_manager.js
@@ -1,0 +1,108 @@
+var Buffer = require('./buffer.js').BufferCountWithTimeout;
+
+/**
+ * Class used to store multiple buffers and add items to them
+ * according to specified configuration.
+ */
+class BufferManager {
+  constructor(cb) {
+    this.buffers = []
+    this.taskBufferMap = {}
+    this.configured = false;
+    this.cb = cb;
+  }
+
+  setCallback(cb) {
+    if (this.cb != undefined) {
+      throw Error("Callback is already set");
+    }
+    this.cb = cb;
+    return;
+  }
+
+  isConfigured() {
+    return this.configured;
+  }
+
+  configure(buffersConf) {
+    /** Configuration cannot be executed more than once. */
+    if (this.configured == true) {
+      throw Error("BufferManager can be configured only once");
+    }
+    this.configured = true;
+
+    /** Parse configuration. */
+    if (Array.isArray(buffersConf) == false) {
+      throw Error("Buffers configuration should be an array");
+    }
+    for (let i = 0; i < buffersConf.length; i++) {
+      let matchTask = buffersConf[i]['matchTask'];
+      let size = buffersConf[i]['size'];
+      let timeoutMs = buffersConf[i]['timeoutMs'];
+      if (matchTask == undefined || size === undefined || timeoutMs == undefined) {
+        throw Error("Following keys are required: matchTask, size, timeoutMs");
+      }
+      let res = this.buffers.push(new Buffer(size, timeoutMs, this.cb));
+      let buffIndex = res - 1;
+
+      /** Build map of taskName -> bufferId. */
+      for (let j = 0; j < matchTask.length; j++) {
+        let taskName = matchTask[j];
+        if (this.taskBufferMap[taskName] != undefined) {
+          console.log("WARNING: task", taskName, "is already matched in another buffer, ignoring");
+          continue;
+        }
+        this.taskBufferMap[taskName] = buffIndex;
+      }
+    }
+
+    return;
+  }
+
+  addItem(taskName, item) {
+    let bufferId = this.taskBufferMap[taskName];
+    /** If task is not buffered, then execute callback immediately. */
+    if (bufferId == undefined) {
+      this.cb([item]);
+      return;
+    }
+
+    /** Buffering item. */
+    this.buffers[bufferId].addItem(item);
+
+    return;
+  }
+}
+
+async function testBufferManager() {
+  let cb = (items) => {
+    console.log("Got from buffer:", items);
+  }
+  buffersConf = [
+    {
+      matchTask: ['job_a', 'job_b'],
+      size: 2,
+      timeoutMs: 3000,
+    },
+    {
+      matchTask: ['job_b', 'job_c'],
+      size: 3,
+      timeoutMs: 2500,
+    },
+  ];
+  let test = new BufferManager(cb)
+  test.configure(buffersConf);
+  test.addItem('job_a', 1);
+  test.addItem('job_a', 2);
+  test.addItem('job_b', 3);
+  test.addItem('job_b', 4);
+  test.addItem('job_b', 5);
+
+  await new Promise(resolve => setTimeout(resolve, 6000));
+
+  test.addItem('job_a', 6);
+  test.addItem('job_c', 7);
+  test.addItem('job_c', 8);
+}
+
+exports.BufferManager = BufferManager;

--- a/functions/kubernetes/k8sCommand.js
+++ b/functions/kubernetes/k8sCommand.js
@@ -1,21 +1,80 @@
 // Runs a job as a Pod (Kubernetes Job) in a Kubernetes cluster
 
 const k8s = require('@kubernetes/client-node');
+var BufferManager = require('./buffer_manager.js').BufferManager;
+var RestartCounter = require('./restart_counter.js').RestartCounter;
 var submitK8sJob = require('./k8sJobSubmit.js').submitK8sJob;
 var fs = require('fs');
 
-async function k8sCommand(ins, outs, context, cb) {
+let bufferManager = new BufferManager();
+
+let backoffLimit = process.env.HF_VAR_BACKOFF_LIMIT || 0;
+let restartCounter = new RestartCounter(backoffLimit);
+
+// Function k8sCommandGroup
+//
+// Inputs:
+// - bufferItems - array containing objects with following properties:
+//   * ins
+//   * outs
+//   * context
+//   * cb
+async function k8sCommandGroup(bufferItems) {
+
+  // No action needed when buffer is empty
+  if (bufferItems.length == 0) {
+    return;
+  }
 
   let startTime = Date.now();
-  console.log("k8sCommand started, time:", startTime);
+  console.log("k8sCommandGroup started, time:", startTime);
+
+  // Function for rebuffering items
+  let restartFn = (bufferIndex) => {
+    let bufferItem = bufferItems[bufferIndex];
+    let taskId = bufferItem.context.taskId;
+    if (restartCounter.isRestartPossible(taskId)) {
+      let restartVal = restartCounter.increase(taskId);
+      console.log("Readding task", taskId, "to buffer (restartCount:", restartVal + ") ...");
+      let itemName = bufferItem.context.name;
+      bufferManager.addItem(itemName, bufferItem);
+    }
+    return;
+  }
+
+  // Extract particular arrays from buffer items
+  let jobArr = [];
+  let taskIdArr = [];
+  let contextArr = [];
+  let cbArr = [];
+  for (let i=0; i<bufferItems.length; i++) {
+    let bufferItem = bufferItems[i];
+    let ins = bufferItem.ins;
+    let outs = bufferItem.outs;
+    let context = bufferItem.context;
+    let cb = bufferItem.cb;
+
+    var job = context.executor; // object containing 'executable', 'args' and others
+    job.name = context.name;
+    job.ins = ins;
+    job.outs = outs;
+
+    jobArr.push(job);
+    taskIdArr.push(context.taskId);
+    contextArr.push(context);
+    cbArr.push(cb);
+  }
+
+  let context = contextArr[0];
+
   // let cluster = await getCluster();
   // const token = await getGCPToken();
 
-  // support for two (or more) clusters (for cloud bursting) 
+  // support for two (or more) clusters (for cloud bursting)
   // if 'partition' is defined, check if there is a custom config file
   // for that partition. This config file may override parameters of the job,
   // possibly even define a path to a different kube_config to be loaded
-  let partition = context.executor.partition; 
+  let partition = context.executor.partition;
   let partitionConfigDir = process.env.HF_VAR_PARTITION_CONFIG_DIR || "/opt/hyperflow/partitions";
   let partitionConfigFile = partitionConfigDir + "/" + "part." + partition + ".config.json";
 
@@ -30,7 +89,7 @@ async function k8sCommand(ins, outs, context, cb) {
   console.log(partitionConfigFile);
   console.log("CUSTOM...", customParams);
 
-  // Set kube_config path if overridden 
+  // Set kube_config path if overridden
   if (customParams.kubeConfigPath) {
       process.env.KUBECONFIG = customParams.kubeConfigPath;
       console.log(process.env.KUBECONFIG);
@@ -39,31 +98,81 @@ async function k8sCommand(ins, outs, context, cb) {
   const kubeconfig = new k8s.KubeConfig();
   kubeconfig.loadFromDefault(); // loadFromString(JSON.stringify(kconfig))
 
-  var job = context.executor; // object containing 'executable', 'args' and others
-  job.name = context.name;
-  job.ins = ins;
-  job.outs = outs;
-
-  let jobExitCode = await submitK8sJob(kubeconfig, job, context.taskId, context, customParams);
+  let jobExitCodes = [];
+  try {
+    jobExitCodes = await submitK8sJob(kubeconfig, jobArr, taskIdArr, contextArr, customParams, restartFn);
+  } catch (err) {
+    console.log("Error when submitting job:", err);
+    throw err;
+  }
 
   let endTime = Date.now();
-  console.log("Ending k8sCommand function, time:", endTime);
+  console.log("Ending k8sCommandGroup function, time:", endTime, "exit codes:", jobExitCodes);
 
   // Stop the entire workflow if a job fails (controlled by an environment variable)
-  if (jobExitCode != 0 && process.env.HF_VAR_STOP_WORKFLOW_WHEN_JOB_FAILED=="1") {
-    console.log('Error: job exited with error code, stopping workflow.');
-    console.log('Error details: job.name: ' + job.name + ', job.args: ' + job.args.join(' '));
-    process.exit(1);
+  for (var i=0; i<jobExitCodes.length; i++) {
+    let jobExitCode = jobExitCodes[i];
+    if (jobExitCode != 0 && process.env.HF_VAR_STOP_WORKFLOW_WHEN_JOB_FAILED=="1") {
+      let taskId = taskIdArr[i];
+      let job = jobArr[i];
+      console.log('Error: job', taskId, 'exited with error code', jobExitCode, ', stopping workflow.');
+      console.log('Error details: job.name: ' + job.name + ', job.args: ' + job.args.join(' '));
+      process.exit(1);
+    }
   }
 
   // if we're here, the job should have succesfully completed -- we write this
   // information to Redis (job executor may make use of it).
-  try {
-    await context.markTaskCompleted();
-  } catch {
-    console.error("Marking job", context.taskId, "as completed failed.")
+  let markPromises = [];
+  for (var i=0; i<contextArr.length; i++) {
+    // skip failed jobs
+    if (jobExitCodes[i] != 0) {
+      continue;
+    }
+
+    let context = contextArr[i];
+    markPromises.push(context.markTaskCompleted());
   }
-  cb(null, outs);
+  try {
+    await Promise.all(markPromises);
+  } catch {
+    console.error("Marking jobs", taskIdArr, "as completed failed.")
+  }
+
+  for (var i=0; i<cbArr.length; i++) {
+    // skip failed jobs
+    if (jobExitCodes[i] != 0) {
+      continue;
+    }
+
+    let cb = cbArr[i];
+    let outs = jobArr[i].outs;
+    cb(null, outs);
+  }
+
+  return;
+}
+
+bufferManager.setCallback((items) => k8sCommandGroup(items));
+
+async function k8sCommand(ins, outs, context, cb) {
+  /** Buffer Manager configuration. */
+  buffersConf = context.appConfig.jobAgglomerations;
+  let alreadyConfigured = bufferManager.isConfigured();
+  if (alreadyConfigured == false && buffersConf != undefined) {
+    bufferManager.configure(buffersConf);
+  }
+
+  /** Buffer item. */
+  let item = {
+    "ins": ins,
+    "outs": outs,
+    "context": context,
+    "cb": cb
+  };
+  bufferManager.addItem(context.name, item);
+
+  return;
 }
 
 exports.k8sCommand = k8sCommand;

--- a/functions/kubernetes/k8sJobSubmit.js
+++ b/functions/kubernetes/k8sJobSubmit.js
@@ -5,47 +5,75 @@ const yaml = require('js-yaml');
 // k8sJobSubmit.js
 // Common functions for job submission to Kubernetes clusters
 
-// Function createK8sJobSpec
+// Function createK8sJobMessage - creates the job message
 //
 // Inputs:
-// - 'job': job definition object; it should contain: 
+// - 'job': job definition object; it should contain:
 //   * 'executable' and 'args' (usually passed via 'context.executor')
 //   * 'ins' and 'outs' (arrays, as passed to the process function)
 //   * 'name': job class name (not unique id), usually passed via 'context.name'
 // - 'taskId': unique task identifier (use 'context.taskId' or define custom)
-// - 'context': pass the 'context' parameter of the process function; 
+// - 'context': pass the 'context' parameter of the process function;
+//    it should contain the 'redis_url'
+//
+// Returns:
+// - jobMessage: string with job command to be sent to a remote executor
+function createK8sJobMessage(job, taskId, context) {
+  let jobMessage = {
+    "executable": job.executable,
+    "args": [].concat(job.args),
+    // "env": job.env || {},
+    "inputs": job.ins.map(i => i),
+    "outputs": job.outs.map(o => o),
+    "stdout": job.stdout, // if present, denotes file name to which stdout should be redirected
+    "stderr": job.stderr, // if present, denotes file name to which stderr should be redirected
+    "stdoutAppend": job.stdoutAppend, // redirect stdout in append mode
+    "stderrAppend": job.stderrAppend, // redirect stderr in append mode
+    "redis_url": context.redis_url,
+    "taskId": taskId,
+    "name": job.name
+  }
+  return jobMessage;
+}
+
+// Function createK8sJobYaml
+//
+// Inputs:
+// - 'job': job definition object; it should contain:
+//   * 'name': job class name (not unique id), usually passed via 'context.name'
+// - 'taskIds': array of unique tasks' identifiers (use '[context.taskId]' or define custom)
+// - 'context': pass the 'context' parameter of the process function;
 //    it should contain the 'redis_url', 'hfId', 'appId'
 // - 'jobYamlTemplate': job YAML that may contain variables '{{varname}}'
 // - 'customParams': JSON object that defines values for variables in the
 //   job's YAML template.
-// 
+//
 // Returns:
-// - JSON object with two strings:
-//   * jobYaml: job YAML to create the k8s job
-//   * jobMessage: job command to be sent to a remote executor
-var createK8sJobSpec = (job, taskId, context, jobYamlTemplate, customParams) => {
-  var command = 'hflow-job-execute "' + taskId + '" ' + context.redis_url;
+// - jobYaml: string with job YAML to create the k8s job
+var createK8sJobYaml = (job, taskIds, context, jobYamlTemplate, customParams) => {
+  let quotedTaskIds = taskIds.map(x => '"' + x + '"');
+  var command = 'hflow-job-execute ' + context.redis_url + ' -a ' + quotedTaskIds.join(' ');
   var containerName = job.image || process.env.HF_VAR_WORKER_CONTAINER;
   var volumePath = '/work_dir';
-  var jobName = Math.random().toString(36).substring(7) + '-' + 
+  var jobName = Math.random().toString(36).substring(7) + '-' +
                 job.name.replace(/_/g, '-') + "-" + context.procId + '-' + context.firingId;
 
   // remove chars not allowd in Pod names
-  jobName = jobName.replace(/[^0-9a-z-]/gi, '').toLowerCase(); 
+  jobName = jobName.replace(/[^0-9a-z-]/gi, '').toLowerCase();
 
   var cpuRequest = job.cpuRequest || process.env.HF_VAR_CPU_REQUEST || "0.5";
   var memRequest = job.memRequest || process.env.HF_VAR_MEM_REQUEST || "50Mi";
 
   // Restart policy -- enable if "HF_VAR_BACKOFF_LIMIT" (number of retries) is defined
-  var backoffLimit = process.env.HF_VAR_BACKOFF_LIMIT || 0; 
-  var restartPolicy = backoffLimit > 0 ? "OnFailure": "Never"; 
+  var backoffLimit = process.env.HF_VAR_BACKOFF_LIMIT || 0;
+  var restartPolicy = backoffLimit > 0 ? "OnFailure": "Never";
 
   var restartCount = 0;
 
   // use string replacement (instead of eval) to evaluate job template
   // 'params' should contain values for variables to be replaced in job template yaml
-  var params = { 
-    command: command, containerName: containerName, 
+  var params = {
+    command: command, containerName: containerName,
     jobName: jobName, volumePath: volumePath,
     cpuRequest: cpuRequest, memRequest: memRequest,
     restartPolicy: restartPolicy, backoffLimit: backoffLimit,
@@ -63,32 +91,21 @@ var createK8sJobSpec = (job, taskId, context, jobYamlTemplate, customParams) => 
   var interpolate = (tpl, args) => tpl.replace(/\${(\w+)}/g, (_, v) => args[v]);
   var jobYaml = yaml.safeLoad(interpolate(jobYamlTemplate, params));
 
-  // create the job message (command to be executed)
-  let jobMessage = {
-    "executable": job.executable,
-    "args": [].concat(job.args),
-    // "env": job.env || {},
-    "inputs": job.ins.map(i => i),
-    "outputs": job.outs.map(o => o),
-    "stdout": job.stdout, // if present, denotes file name to which stdout should be redirected
-    "stderr": job.stderr, // if present, denotes file name to which stderr should be redirected
-    "stdoutAppend": job.stdoutAppend, // redirect stdout in append mode
-    "stderrAppend": job.stderrAppend, // redirect stderr in append mode
-    "redis_url": context.redis_url,
-    "taskId": taskId,
-    "name": job.name
-  }
-
-  return { jobYaml: jobYaml, jobMessage: jobMessage };
+  return jobYaml;
 }
 
 // Function submitK8sJob
 // Submits a job to a Kubernetes cluster and awaits for its completion
 //
-// Inputs: see inputs to 'createK8sJobSpec'
+// Inputs:
+// - see inputs to 'createK8sJobYaml' and 'createK8sJobMessage'
+// - restartFn - function that will be called in case of failed job
+//
+//
 // Returns: job exit code
-var submitK8sJob = async(kubeconfig, job, taskId, context, customParams) => {
-  var command = 'hflow-job-execute ' + taskId + ' ' + context.redis_url;
+var submitK8sJob = async(kubeconfig, jobArr, taskIdArr, contextArr, customParams, restartFn) => {
+
+  let context = contextArr[0];
 
   // Load definition of the the worker job pod
   // File 'job-template.yaml' should be provided externally during deployment
@@ -96,26 +113,33 @@ var submitK8sJob = async(kubeconfig, job, taskId, context, customParams) => {
   var jobYamlTemplate = fs.readFileSync(jobTemplatePath, 'utf8');
   //var job = yaml.safeLoad(eval('`'+jobYaml+'`')); // this works, but eval unsafe
 
-  var jobSpec = createK8sJobSpec(job, taskId, context, jobYamlTemplate, customParams);
-  var jobYaml = jobSpec.jobYaml;
-  var jobMessage = jobSpec.jobMessage;
+  // CAUTION: When creating job YAML first job details (requests, container) are used.
+  var jobYaml = createK8sJobYaml(jobArr[0], taskIdArr, context, jobYamlTemplate, customParams);
+  let jobMessages = [];
+  for (var i=0; i<jobArr.length; i++) {
+    let job = jobArr[i];
+    let taskId = taskIdArr[i];
+
+    let jobMessage = createK8sJobMessage(job, taskId, context);
+    jobMessages.push(jobMessage);
+  }
 
   // Test mode -- just print, do not actually create jobs
   if (process.env.HF_VAR_K8S_TEST=="1") {
     console.log(JSON.stringify(jobYaml, null, 4));
-    console.log(JSON.stringify(jobMessage, null, 2));
+    console.log(JSON.stringify(jobMessages, null, 2));
     return 0;
   }
 
   var namespace = process.env.HF_VAR_NAMESPACE || 'default';
 
   let taskStart = new Date().toISOString();
-  console.log("Starting task", taskId, 'time=' + taskStart);
+  console.log("Starting tasks", taskIdArr, 'time=' + taskStart);
 
   const k8sApi = kubeconfig.makeApiClient(k8s.BatchV1Api);
 
   // Create the job via the Kubernetes API. We implement a simple retry logic
-  // in case the API is overloaded and returns HTTP 429 (Too many requests). 
+  // in case the API is overloaded and returns HTTP 429 (Too many requests).
   var createJob = function(attempt) {
     try {
       k8sApi.createNamespacedJob(namespace, jobYaml).then(
@@ -134,7 +158,7 @@ var submitK8sJob = async(kubeconfig, job, taskId, context, customParams) => {
             case 429: // 'Too many requests' -- API overloaded
               // Calculate delay: default 1s, for '429' we should get it in the 'retry-after' header
               let delay = Number(err.response.headers['retry-after'] || 1)*1000;
-              console.log("Create k8s job", taskId, "HTTP error " + statusCode + " (attempt " + attempt + 
+              console.log("Create k8s job", taskIdArr, "HTTP error " + statusCode + " (attempt " + attempt +
                            "), retrying after " + delay + "ms." );
               setTimeout(() => createJob(attempt+1), delay);
               break;
@@ -151,11 +175,17 @@ var submitK8sJob = async(kubeconfig, job, taskId, context, customParams) => {
       console.error(e);
     }
   }
-  createJob(1); 
+  createJob(1);
 
+  let sendJobMessagesPromises = [];
+  for (var i=0; i<jobMessages.length; i++) {
+    let taskId = taskIdArr[i];
+    let jobMessage = jobMessages[i];
+    sendJobMessagesPromises.push(context.sendMsgToJob(JSON.stringify(jobMessage), taskId));
+  }
   try {
-    console.log("Sending job message to", taskId);
-    await context.sendMsgToJob(JSON.stringify(jobMessage), taskId);
+    console.log("Sending job messages to", taskIdArr);
+    await Promise.all(sendJobMessagesPromises);
   } catch (err) {
     console.error(err);
     throw err;
@@ -163,8 +193,8 @@ var submitK8sJob = async(kubeconfig, job, taskId, context, customParams) => {
 
   // 'awaitJob' -- wait for the job to finish, possibly restarting it
   // Restart policy -- enable if "HF_VAR_BACKOFF_LIMIT" (number of retries) is defined
-  var backoffLimit = process.env.HF_VAR_BACKOFF_LIMIT || 0; 
-  var restartPolicy = backoffLimit > 0 ? "OnFailure": "Never"; 
+  var backoffLimit = process.env.HF_VAR_BACKOFF_LIMIT || 0;
+  var restartPolicy = backoffLimit > 0 ? "OnFailure": "Never";
   var restartCount = 0;
   var awaitJob = async(taskId) => {
     try {
@@ -176,24 +206,31 @@ var submitK8sJob = async(kubeconfig, job, taskId, context, customParams) => {
     let taskEnd = new Date().toISOString();
     console.log('Job ended with result:', jobResult, 'time:', taskEnd);
     var code = parseInt(jobResult[1]); // job exit code
-    // if job failed and restart policy is enabled, restart the job
-    if (code != 0 && restartPolicy == "OnFailure" && restartCount++ < backoffLimit)  {
-      console.log("Job", taskId, "failed, restarting (restartCount:", restartCount + ") ...");
-      // When restarting, need to send the message job again!
-      try {
-        await context.sendMsgToJob(jobMessage, taskId);
-      } catch (err) {
-        console.error(err);
-        throw err;
-      }
-      return awaitJob(taskId); // just wait again assuming Kubernetes will restart the job
-    } 
     return code;
   }
 
-  let jobExitCode = awaitJob(taskId);
-  return jobExitCode;
+  var awaitJobs = async(taskIdArr) => {
+    let awaitPromises = []
+    for (var i=0; i<taskIdArr.length; i++) {
+      awaitPromises.push(awaitJob(taskIdArr[i]));
+    }
+    return Promise.all(awaitPromises);
+  }
+
+  let jobExitCodes = await awaitJobs(taskIdArr);
+  for (let i = 0; i < jobExitCodes.length; i++) {
+    let jobExitCode = jobExitCodes[i];
+    let taskId = taskIdArr[i];
+    if (jobExitCode != 0) {
+      console.log("Job", taskId, "failed");
+      restartFn(i);
+      // NOTE: job message is preserved, so we don't have to send it again.
+    }
+  }
+
+  return jobExitCodes;
 }
 
 exports.submitK8sJob = submitK8sJob;
-exports.createK8sJobSpec = createK8sJobSpec;
+exports.createK8sJobYaml = createK8sJobYaml;
+exports.createK8sJobMessage = createK8sJobMessage;

--- a/functions/kubernetes/restart_counter.js
+++ b/functions/kubernetes/restart_counter.js
@@ -1,0 +1,59 @@
+/**
+ * Class used for counting job restarts.
+ */
+class RestartCounter {
+  constructor(backoffLimit) {
+    this.backoffLimit = backoffLimit;
+    this.counters = {}
+  }
+
+  isRestartPossible(item) {
+    let counter = this.counters[item];
+    if (counter == undefined && this.backoffLimit > 0) {
+      return true;
+    }
+    let possible = counter < this.backoffLimit;
+    return possible;
+  }
+
+  increase(item) {
+    if (this.counters[item] == undefined) {
+      this.counters[item] = 0;
+    }
+    this.counters[item] += 1;
+    let counterVal = this.counters[item];
+    return counterVal;
+  }
+}
+
+
+/**
+ * Testing function.
+ * TODO: REMOVE
+ */
+const assert = require('assert');
+async function testRestartCounter() {
+  let test = new RestartCounter(2);
+
+  assert.strictEqual(test.isRestartPossible("item1"), true);
+  assert.strictEqual(test.increase("item1"), 1);
+  assert.strictEqual(test.isRestartPossible("item1"), true);
+  assert.strictEqual(test.increase("item1"), 2);
+  assert.strictEqual(test.isRestartPossible("item1"), false);
+
+  assert.strictEqual(test.isRestartPossible("item2"), true);
+  assert.strictEqual(test.increase("item2"), 1);
+  assert.strictEqual(test.isRestartPossible("item2"), true);
+  assert.strictEqual(test.increase("item2"), 2);
+  assert.strictEqual(test.isRestartPossible("item2"), false);
+
+  let test2 = new RestartCounter(0);
+  assert.strictEqual(test2.isRestartPossible("item1"), false);
+  assert.strictEqual(test2.increase("item1"), 1);
+  assert.strictEqual(test2.isRestartPossible("item1"), false);
+  assert.strictEqual(test2.isRestartPossible("item2"), false);
+  assert.strictEqual(test2.increase("item2"), 1);
+  assert.strictEqual(test2.isRestartPossible("item2"), false);
+}
+
+exports.RestartCounter = RestartCounter;


### PR DESCRIPTION
_This is change regarding _k8sCommand_ function in HyperFlow._

### Agglomerating jobs

When workflow consists of many similar small tasks, the scheduling and creating kubernetes' jobs can take more time than executing tasks itself - there should be an option to avoid this overhead.

Currently model of execution looks more or less like this:

![arch_before](https://user-images.githubusercontent.com/6506780/94830298-ba332f00-040b-11eb-8388-fbe5985081c3.png)

I would like to introduce buffering layer that will collect tasks and pass them in groups:

![arch_after](https://user-images.githubusercontent.com/6506780/94830294-b99a9880-040b-11eb-88f5-0bf320f591d6.png)

**The most crucial details:**

- Tasks are buffered until timeout passes or buffer reach its size.
- Each buffer can specify matching task's names and configure its timeout and size.
- Existing functionality is preserved, so if you not configure _job agglomeration_ on purpose, then you will get old behavior.
- "Rules" of agglomerating can configured via _workflow.json_

### Comparing results

This is montage (0.25 degree) execution WITHOUT configured job agglomerations:

![normal_execution](https://user-images.githubusercontent.com/6506780/94830596-08483280-040c-11eb-9ca9-dce61f6f718c.png)

To configure it we add `jobAgglomerations` to **first** task config:

![image](https://user-images.githubusercontent.com/6506780/94831174-afc56500-040c-11eb-8621-bc4cdbf6445b.png)

Then we can observe that execution is performed in job agglomerations - _red_, _orange_, _green_ are grouped: 
![buffered_execution](https://user-images.githubusercontent.com/6506780/94830599-09795f80-040c-11eb-8345-e704126d6230.png)
