### PR TITLE
[k8s] Fix passing taskIds

### DIFF
--- a/functions/kubernetes/k8sJobSubmit.js
+++ b/functions/kubernetes/k8sJobSubmit.js
@@ -52,7 +52,7 @@ function createK8sJobMessage(job, taskId, context) {
 // - jobYaml: string with job YAML to create the k8s job
 var createK8sJobYaml = (job, taskIds, context, jobYamlTemplate, customParams) => {
   let quotedTaskIds = taskIds.map(x => '"' + x + '"');
-  var command = 'hflow-job-execute ' + context.redis_url + ' -a ' + quotedTaskIds.join(' ');
+  var command = 'hflow-job-execute ' + context.redis_url + ' -a -- ' + quotedTaskIds.join(' ');
   var containerName = job.image || process.env.HF_VAR_WORKER_CONTAINER;
   var volumePath = '/work_dir';
   var jobName = Math.random().toString(36).substring(7) + '-' +


### PR DESCRIPTION
Since https://github.com/hyperflow-wms/hyperflow-job-executor/pull/9 is merged we should use positional arguments separator '--', so event tasks starting with '-' will be parsed correctly.